### PR TITLE
Handle exit from Mix.Project.load_paths (instead of crashing node)

### DIFF
--- a/lib/reprise.ex
+++ b/lib/reprise.ex
@@ -124,7 +124,17 @@ defmodule Reprise.Runner do
   Returns all beam files belonging to the current mix project.
   """
   @spec beams() :: [beam]
-  def beams(), do: iterate_beams(Mix.Project.load_paths)
+  def beams() do
+    beams = try do
+              Mix.Project.load_paths
+            catch
+              _,_ ->
+                Logger.error "Unable to load mix paths. Stopping application reprise."
+                Application.stop :reprise
+                []
+            end
+    iterate_beams beams
+  end
 
   @doc """
   Returns pairs of beam files and modules which are loaded


### PR DESCRIPTION
This handles the situation where reprise gets packaged into a release, where a call to Mix.Project.load_paths results in this error:

```
18:33:15.626 [error] GenServer Reprise terminating
Last message: :wake
State: {{{2014, 10, 31}, {18, 33, 14}}, 1000}
** (exit) an exception was raised:
    ** (Mix.Error) Cannot access build without an application name, please ensure you are in a directory with a mix.exs file and it defines an :app name under the project configuration
        (mix) lib/mix.ex:235: Mix.raise/1
        (mix) lib/mix/project.ex:303: Mix.Project.compile_path/1
        (mix) lib/mix/project.ex:343: Mix.Project.load_paths/1
        (reprise) lib/reprise.ex:129: Reprise.Runner.beams/0
        (reprise) lib/reprise.ex:144: Reprise.Runner.beam_modules/0
        (reprise) lib/reprise.ex:171: Reprise.Runner.go/2
        (reprise) lib/reprise.ex:81: Reprise.Server.handle_info/2
        (stdlib) gen_server.erl:599: :gen_server.handle_msg/5
```

Instead of crashing the node, it causes the reprise application to terminate.
