### PR TITLE
In absence of Mix, scan all paths

### DIFF
--- a/lib/reprise.ex
+++ b/lib/reprise.ex
@@ -126,7 +126,8 @@ defmodule Reprise.Runner do
   @spec beams() :: [beam]
   def beams() do
     beams = try do
-              Mix.Project.load_paths
+              (function_exported?(Mix.Project, :load_paths, 0) && Mix.Project.load_paths) ||
+              :code.get_path
             catch
               _,_ ->
                 Logger.error "Unable to load mix paths. Stopping application reprise."


### PR DESCRIPTION
In some use cases (in my particular case, I build a 'dev' release with exrm (mix release --dev) that symlinks into my _build tree so that anytime I recompile, I want the release to pick up the change. However, there's no Mix during that time anymore; so my suggestion is to revert to all available load paths when that happens.