### PR TITLE
add reload hook test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Reprise.Mixfile do
   def project do
     [app: :reprise,
      version: "0.4.1-dev",
-     elixir: "~> 1.0.0",
+     elixir: ">= 1.0.0",
      description: description,
      package: package,
      deps: deps]

--- a/test/reprise_test.exs
+++ b/test/reprise_test.exs
@@ -6,6 +6,13 @@ defmodule RepriseTest do
 
   doctest Reprise.Server
 
+  def _reprise_on_reload do
+    case :erlang.get(:hook_test) do
+      :undefined -> :erlang.put(:hook_test, 1)
+      n -> :erlang.put(:hook_test, n+1)
+    end
+  end
+
   test "my own beams have proper names" do
     for b <- Reprise.Runner.beams,
       f = b |> Path.split |> List.last,
@@ -23,6 +30,12 @@ defmodule RepriseTest do
     refute mods == []
     for m <- mods, do:
       assert "#{m}" =~ ~r/^Elixir\.Reprise\b/
+  end
+
+  test "can call reload hook" do 
+    Reprise.Runner.call_reload_hook(RepriseTest)
+    Reprise.Runner.call_reload_hook(RepriseTest)
+    assert :erlang.get(:hook_test) == 2
   end
 
 end


### PR DESCRIPTION
This is a simple test for calling reloading hooks.

For this to run on my machine, I've changed supported elixir version to ">= 1.0.0". Not sure if it's appropriate at the moment, but I'm good using the lib in 1.1.1 so far.
