### PR TITLE
Feature/ensure local time

### DIFF
--- a/lib/reprise.ex
+++ b/lib/reprise.ex
@@ -178,7 +178,7 @@ defmodule Reprise.Runner do
   @spec go(time, time) :: :ok | nil
   def go(from, to) do
     modules = for {f,m} <- beam_modules do
-      case File.stat(f) do
+      case File.stat(f, time: :local) do
         {:ok, %File.Stat{mtime: mtime}} when mtime >= from and mtime < to ->
           case reload(m) do
             {:module, m} -> {:reloaded, m}

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Reprise.Mixfile do
 
   def project do
     [app: :reprise,
-     version: "0.4.3-dev",
+     version: "0.4.4-dev",
      elixir: "~> 1.0",
      description: description,
      package: package,


### PR DESCRIPTION
This PR forces the `File.stat` output to use `:local` time so that it can make a valid comparison against values generated by `Reprise.Server.now/0` which uses `:erlang.localtime`.

It also bumps the version to `0.4.4-dev`.