### PR TITLE
Fix compiler warnings for deprecated libraries

### DIFF
--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -39,11 +39,11 @@ defmodule Reprise.Runner do
   """
   @spec beam_modules([beam]) :: [{beam, module}]
   def beam_modules(beams \\ __MODULE__.beams) do
-    beamset = beams |> Enum.into(HashSet.new)
+    beamset = beams |> Enum.into(MapSet.new)
     for {m,f} <- :code.all_loaded,
       is_list(f),
       f = Path.expand(f),
-      Set.member?(beamset, f),
+      MapSet.member?(beamset, f),
       do: {f,m}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Reprise.Mixfile do
   def project do
     [app: :reprise,
      version: "0.5.2-dev",
-     elixir: "~> 1.0",
+     elixir: "~> 1.1",
      description: description(),
      package: package(),
      deps: deps()]


### PR DESCRIPTION
Remove deprecated `HashSet` and `Set` calls. `MapSet` has been available since Elixir 1.1 - hopefully most people have upgraded at least that far by now :)